### PR TITLE
add check for removal of last ethernet interface

### DIFF
--- a/70-wifi-wired-exclusive.sh
+++ b/70-wifi-wired-exclusive.sh
@@ -10,8 +10,19 @@ fi
 
 interface="$1"
 iface_mode="$2"
-iface_type=$(nmcli dev | grep "$interface" | tr -s ' ' | cut -d' ' -f2)
-iface_state=$(nmcli dev | grep "$interface" | tr -s ' ' | cut -d' ' -f3)
+iface_type=$(nmcli dev | grep "^$interface$" | tr -s ' ' | cut -d' ' -f2)
+iface_state=$(nmcli dev | grep "^$interface$" | tr -s ' ' | cut -d' ' -f3)
+
+# Check, if an ethernet is left
+# This is needed if the ethernet-interface is getting unplugged
+connected_ethernets_left=$(nmcli dev | grep "\sethernet\s" | tr -s ' ' | cut -d' ' -f3 | grep "connected")
+
+# Check, if we try to switch off wifi
+# If we are on wifi and want to switch it off, we should not consider, if
+# no ethernet is left, because then we just switch it on again.
+if [ "$iface_type" = "wifi" ] && [ $connected_ethernet_left != 0 ]; then
+  switch_without_ethernet = 1
+fi
 
 logger -i -t "$syslog_tag" "Interface: $interface = $iface_state ($iface_type) is $iface_mode"
 
@@ -25,7 +36,7 @@ disable_wifi() {
    nmcli radio wifi off
 }
 
-if [ "$iface_type" = "ethernet" ] && [ "$iface_mode" = "down" ]; then
+if [ "$iface_type" = "ethernet" ] || [ "$switch_without_ethernet" ] && [ "$iface_mode" = "down" ]; then
   enable_wifi
 elif [ "$iface_type" = "ethernet" ] && [ "$iface_mode" = "up"  ] && [ "$iface_state" = "connected" ]; then
   disable_wifi


### PR DESCRIPTION
* If there is e.g. only one usb ethernet interface and it is getting
  unplugged, the script is not able to get the status of this unplugged
  interface and fails to turn on wifi.
  This should help.